### PR TITLE
Removed superstitious condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,6 @@ function match(path, params, pathname) {
   var m = regexp.exec(pathname);
 
   if (!m) return false;
-  else if (!params) return true;
 
   for (var i = 1, len = m.length; i < len; ++i) {
     var key = keys[i - 1];


### PR DESCRIPTION
Params will only ever be an empty object, because the enroute function always passes an empty object and the only way match is invoked is through enroute.  IMO, it would be better form for match to return a param object that it defines rather than mutating a parameter.